### PR TITLE
Keine Willkommensnachricht für Nutzer, die von Multiplikatoren erstellt wurden

### DIFF
--- a/app/Observers/UserObserver.php
+++ b/app/Observers/UserObserver.php
@@ -39,12 +39,18 @@ class UserObserver extends BaseObserver
      */
     public function created(User $user)
     {
-        // Prüfen, ob der Benutzer nicht durch einen Multiplikator erstellt wurde
-        if (!$user->created_by || !$user->created_by->hasRole(config('permission.project_roles.user_multiplier'))) {
-            $user->sendWelcomeNotification(
-                $this->tokens->create($user)
-            );
+        // Hole den aktuellen Benutzer
+        $currentUser = auth()->user();
+
+        // Prüfen, ob der aktuelle Benutzer die Rolle "Multiplikator" hat
+        if ($currentUser && $currentUser->hasRole(config('permission.project_roles.user_multiplier'))) {
+            return;
         }
+
+        // Wenn der aktuelle Benutzer kein Multiplikator ist, Willkommensnachricht senden
+        $user->sendWelcomeNotification(
+            $this->tokens->create($user)
+        );
     }
 
     /**


### PR DESCRIPTION
Es wurde ein Fehler behoben, bei dem die Willkommensnachricht auch dann versendet wurde, wenn der Benutzer durch einen Multiplikator erstellt wurde. Die Logik wurde angepasst, um die Rolle des aktuell angemeldeten Benutzers (currentUser) zu überprüfen. Wenn dieser die Rolle “Multiplikator” besitzt, wird die Willkommensnachricht nun nicht mehr versendet.